### PR TITLE
Fix issue #52

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -116,7 +116,7 @@ class InfModel(object):
                               tf.expand_dims(tf.nn.softmax(logits2), axis=1))
             outer = tf.cond(
                 self.tokens_in_context < self.max_answer_tokens,
-                lambda: outer,
+                lambda: tf.matrix_band_part(outer, 0, -1),
                 lambda: tf.matrix_band_part(outer, 0, self.max_answer_tokens))
             self.yp1 = tf.argmax(tf.reduce_max(outer, axis=2), axis=1)
             self.yp2 = tf.argmax(tf.reduce_max(outer, axis=1), axis=1)

--- a/inference.py
+++ b/inference.py
@@ -27,12 +27,16 @@ char2idx_file = os.path.join(target_dir, "char2idx.json")
 
 
 class InfModel(object):
+    # Used to zero elements in the probability matrix that correspond to answer
+    # spans that are longer than the number of tokens specified here.
+    max_answer_tokens = 15
 
     def __init__(self, word_mat, char_mat):
         self.c = tf.placeholder(tf.int32, [1, None])
         self.q = tf.placeholder(tf.int32, [1, None])
         self.ch = tf.placeholder(tf.int32, [1, None, char_limit])
         self.qh = tf.placeholder(tf.int32, [1, None, char_limit])
+        self.tokens_in_context = tf.placeholder(tf.int64)
 
         self.word_mat = tf.get_variable("word_mat", initializer=tf.constant(
             word_mat, dtype=tf.float32), trainable=False)
@@ -110,7 +114,10 @@ class InfModel(object):
         with tf.variable_scope("predict"):
             outer = tf.matmul(tf.expand_dims(tf.nn.softmax(logits1), axis=2),
                               tf.expand_dims(tf.nn.softmax(logits2), axis=1))
-            outer = tf.matrix_band_part(outer, 0, 15)
+            outer = tf.cond(
+                self.tokens_in_context < self.max_answer_tokens,
+                lambda: outer,
+                lambda: tf.matrix_band_part(outer, 0, self.max_answer_tokens))
             self.yp1 = tf.argmax(tf.reduce_max(outer, axis=2), axis=1)
             self.yp2 = tf.argmax(tf.reduce_max(outer, axis=1), axis=1)
 
@@ -143,7 +150,8 @@ class Inference(object):
                 [model.yp1, model.yp2],
                 feed_dict={
                     model.c: context_idxs, model.q: ques_idxs,
-                    model.ch: context_char_idxs, model.qh: ques_char_idxs})
+                    model.ch: context_char_idxs, model.qh: ques_char_idxs,
+                    model.tokens_in_context: len(span)})
         start_idx = span[yp1[0]][0]
         end_idx = span[yp2[0]][1]
         return context[start_idx: end_idx]

--- a/inference.py
+++ b/inference.py
@@ -55,7 +55,9 @@ class InfModel(object):
         self.ready()
 
     def ready(self):
-        N, PL, QL, CL, d, dc, dg = 1, self.c_maxlen, self.q_maxlen, char_limit, hidden, char_dim, char_hidden
+        N, PL, QL, CL, d, dc, dg = \
+            1, self.c_maxlen, self.q_maxlen, char_limit, hidden, char_dim, \
+            char_hidden
         gru = cudnn_gru if use_cudnn else native_gru
 
         with tf.variable_scope("emb"):
@@ -134,10 +136,14 @@ class Inference(object):
     def response(self, context, question):
         sess = self.sess
         model = self.model
-        span, context_idxs, ques_idxs, context_char_idxs, ques_char_idxs = self.prepro(
-            context, question)
-        yp1, yp2 = sess.run([model.yp1, model.yp2], feed_dict={
-                            model.c: context_idxs, model.q: ques_idxs, model.ch: context_char_idxs, model.qh: ques_char_idxs})
+        span, context_idxs, ques_idxs, context_char_idxs, ques_char_idxs = \
+            self.prepro(context, question)
+        yp1, yp2 = \
+            sess.run(
+                [model.yp1, model.yp2],
+                feed_dict={
+                    model.c: context_idxs, model.q: ques_idxs,
+                    model.ch: context_char_idxs, model.qh: ques_char_idxs})
         start_idx = span[yp1[0]][0]
         end_idx = span[yp2[0]][1]
         return context[start_idx: end_idx]


### PR DESCRIPTION
Fixes issue #52.

Text below from https://github.com/ericchansen/r-net/commit/ea3331929e6d64ef1eea41e6acd7acacf86cfff7.

Previously, the script would return an error if the passage was less than 15
tokens.

For example, let's say the passage consists of only 11 tokens. The probability
matrix, defined in `inference.py` as `outer`, would be 11 x 11. This would cause
`tf.matrix_band_part(outer, 0, 15)` to return an error.

`outer` is a a symmetric matrix. `tf.matrix_band_part(outer, 0, 15)` zeros the
lower triangle (it's redundant with the upper triangle because `outer` is a
symmetric matrix). `tf.matrix_band_part(outer, 0, 15)` also zeros any elements
in the probability matrix that correspond to answers longer than 15 tokens.

In this commit, the maximum number of tokens in an answer is more clearly
defined as `max_answer_tokens = 15`. Users can easily set this variable to
whatever integer they prefer. `tf.matrix_band_part(outer, 0, 15)` is now
`tf.matrix_band_part(outer, 0, self.max_answer_tokens)`.

Also, if a passage contains less tokens than `max_answer_tokens`, then the
operation `tf.matrix_band_part(outer, 0, self.max_answer_tokens)` is ignored.
This prevents any error from occuring when the user provides a particularly
short passage. Instead, R-NET will simply return the most probable answer span
in the passage without first doing any truncation of probability matrix.